### PR TITLE
Build time fix

### DIFF
--- a/balance/units/DAL0310/DAL0310_unit.bp
+++ b/balance/units/DAL0310/DAL0310_unit.bp
@@ -21,9 +21,9 @@ BlueprintId = "dal0310",
         'OVERLAYDIRECTFIRE',
     },
     Economy = {
-        BuildCostEnergy = 9250,
-        BuildCostMass = 518,
-        BuildTime = 3700,
+        BuildCostEnergy = 5200,
+        BuildCostMass = 520,
+        BuildTime = 2600,
     },
     Weapon = {
         {

--- a/balance/units/DALK003/DALK003_unit.bp
+++ b/balance/units/DALK003/DALK003_unit.bp
@@ -9,7 +9,7 @@ BlueprintId = "dalk003",
         MaxHealth = 1900,
     },
     Economy = {
-        BuildCostEnergy = 9500,
+        BuildCostEnergy = 7600,
         BuildCostMass = 760,
         BuildTime = 3800,
     },

--- a/balance/units/DELK002/DELK002_unit.bp
+++ b/balance/units/DELK002/DELK002_unit.bp
@@ -9,7 +9,7 @@ BlueprintId = "delk002",
         MaxHealth = 2200,
     },
     Economy = {
-        BuildCostEnergy = 9500,
+        BuildCostEnergy = 7600,
         BuildCostMass = 760,
         BuildTime = 3800,
     },    

--- a/balance/units/DRLK001/DRLK001_unit.bp
+++ b/balance/units/DRLK001/DRLK001_unit.bp
@@ -25,7 +25,7 @@ BlueprintId = "drlk001",
         MaxHealth = 1800,   --from 1900
     },
     Economy = {
-        BuildCostEnergy = 10500,    --from 10000
+        BuildCostEnergy = 8400,    --from 10000
         BuildCostMass = 840,        --from 800
         BuildTime = 4200,           --from 4000
     },

--- a/balance/units/DSLK004/DSLK004_unit.bp
+++ b/balance/units/DSLK004/DSLK004_unit.bp
@@ -9,7 +9,7 @@ BlueprintId = "dslk004",
         MaxHealth = 2000,
     },
     Economy = {
-        BuildCostEnergy = 10500,
+        BuildCostEnergy = 8400,
         BuildCostMass = 840,
         BuildTime = 4200,
     },

--- a/balance/units/UAL0111/UAL0111_unit.bp
+++ b/balance/units/UAL0111/UAL0111_unit.bp
@@ -9,9 +9,9 @@ BlueprintId = "ual0111",
         MaxHealth = 650,
     },
     Economy = {
-        BuildCostEnergy = 2100,
-        BuildCostMass = 196,
-        BuildTime = 1400,
+        BuildCostEnergy = 1000,
+        BuildCostMass = 200,
+        BuildTime = 1000,
     },
     Weapon = {
         {                       -- projectile is faster

--- a/balance/units/UAL0304/UAL0304_unit.bp
+++ b/balance/units/UAL0304/UAL0304_unit.bp
@@ -5,9 +5,9 @@ Merge = true,
 BlueprintId = "ual0304", 
 
     Economy = {
-        BuildCostEnergy = 12000,
+        BuildCostEnergy = 8400,
         BuildCostMass = 840,
-        BuildTime = 6000,
+        BuildTime = 4200,
     },
     Weapon = {
         {

--- a/balance/units/UAL0307/UAL0307_unit.bp
+++ b/balance/units/UAL0307/UAL0307_unit.bp
@@ -38,9 +38,9 @@ BlueprintId = "ual0307",
             RULEUCC_Transport = false,
         },
     Economy = {
-        BuildCostEnergy = 1350,    --75e per sec
-        BuildCostMass = 126,    --7m per sec
-        BuildTime = 900,        --18s
+        BuildCostEnergy = 1300,    --100e per sec
+        BuildCostMass = 130,    --10m per sec
+        BuildTime = 650,        --13s
     },
     Defense = {
         Shield = {

--- a/balance/units/UAS0304/UAS0304_unit.bp
+++ b/balance/units/UAS0304/UAS0304_unit.bp
@@ -9,9 +9,9 @@ BlueprintId="uas0304",
         MaxHealth = 4500,
     },
     Economy = {
-        BuildCostEnergy = 105000,
-        BuildCostMass = 7000,
-        BuildTime = 36000,
+        BuildCostEnergy = 139500,
+        BuildCostMass = 6975,
+        BuildTime = 27900,
     },
     Intel = {
         SonarRadius = 60,

--- a/balance/units/UEL0111/UEL0111_unit.bp
+++ b/balance/units/UEL0111/UEL0111_unit.bp
@@ -5,9 +5,9 @@ Merge = true,
 BlueprintId = "uel0111",
 
     Economy = {
-        BuildCostEnergy = 1400,
-        BuildCostMass = 196,
-        BuildTime = 1400,
+        BuildCostEnergy = 1000,
+        BuildCostMass = 200,
+        BuildTime = 1000,
     },
     Weapon = {
         {

--- a/balance/units/UEL0304/UEL0304_unit.bp
+++ b/balance/units/UEL0304/UEL0304_unit.bp
@@ -5,9 +5,9 @@ Merge = true,
 BlueprintId = "uel0304", 
 
     Economy = {
-        BuildCostEnergy = 12000,
+        BuildCostEnergy = 8400,
         BuildCostMass = 840,
-        BuildTime = 6000,
+        BuildTime = 4200,
     },
     Weapon = {
         {

--- a/balance/units/UEL0307/UEL0307_unit.bp
+++ b/balance/units/UEL0307/UEL0307_unit.bp
@@ -5,9 +5,9 @@ Merge = true,
 BlueprintId = "uel0307",
 
     Economy = {
-        BuildCostEnergy = 1125,    --75e per sec
-        BuildCostMass = 105,    --7m per sec
-        BuildTime = 750,        --15s
+        BuildCostEnergy = 1100,    --100e per sec
+        BuildCostMass = 110,    --10m per sec
+        BuildTime = 550,        --11s
         MaintenanceConsumptionPerSecondEnergy = 100,
     },
     Defense = {

--- a/balance/units/UES0304/UES0304_unit.bp
+++ b/balance/units/UES0304/UES0304_unit.bp
@@ -9,9 +9,9 @@ BlueprintId="ues0304",
         MaxHealth = 4750,
     },
     Economy = {
-        BuildCostEnergy = 105000,
-        BuildCostMass = 7000,
-        BuildTime = 36000,
+        BuildCostEnergy = 139500,
+        BuildCostMass = 6975,
+        BuildTime = 27900,
     },
     Intel = {
         SonarRadius = 60,

--- a/balance/units/URL0111/URL0111_unit.bp
+++ b/balance/units/URL0111/URL0111_unit.bp
@@ -5,9 +5,9 @@ Merge = true,
 BlueprintId = "url0111",
 
     Economy = {
-        BuildCostEnergy = 1400,
-        BuildCostMass = 196,
-        BuildTime = 1400,
+        BuildCostEnergy = 1000,
+        BuildCostMass = 200,
+        BuildTime = 1000,
     },
     Weapon = {
         {                      

--- a/balance/units/URL0304/URL0304_unit.bp
+++ b/balance/units/URL0304/URL0304_unit.bp
@@ -5,9 +5,9 @@ Merge = true,
 BlueprintId = "url0304", 
 
     Economy = {
-        BuildCostEnergy = 12000,
+        BuildCostEnergy = 8400,
         BuildCostMass = 840,
-        BuildTime = 6000,
+        BuildTime = 4200,
     },
     Weapon = {
         {

--- a/balance/units/URL0306/URL0306_unit.bp
+++ b/balance/units/URL0306/URL0306_unit.bp
@@ -10,9 +10,9 @@ BlueprintId = "url0306",
         RegenRate = 5,        --from 0 because cant get veterancy
     },
     Economy = {
-        BuildCostEnergy = 900,    --75e per sec
-        BuildCostMass = 84,        --7m per sec
-        BuildTime = 600,        --12s
+        BuildCostEnergy = 900,    --100e per sec
+        BuildCostMass = 90,        --10m per sec
+        BuildTime = 450,        --9s
         MaintenanceConsumptionPerSecondEnergy = 50,
     },
     Weapon = {

--- a/balance/units/URS0304/URS0304_unit.bp
+++ b/balance/units/URS0304/URS0304_unit.bp
@@ -9,9 +9,9 @@ BlueprintId="urs0304",
         MaxHealth = 5000,
     },
     Economy = {
-        BuildCostEnergy = 78750,
-        BuildCostMass = 5250,
-        BuildTime = 27000,
+        BuildCostEnergy = 107100,
+        BuildCostMass = 5220,
+        BuildTime = 20880,
         MaintenanceConsumptionPerSecondEnergy = 100,
     },
     General = {

--- a/balance/units/XEL0209/XEL0209_unit.bp
+++ b/balance/units/XEL0209/XEL0209_unit.bp
@@ -5,7 +5,7 @@ Merge = true,
 BlueprintId = "xel0209",
 
     Economy = {
-        BuildCostEnergy = 1400,    --75e per sec
+        BuildCostEnergy = 1400,    --50e per sec
         BuildCostMass = 280,    --10m per sec
         BuildTime = 1400,        --25s
         BuildRate = 20,            --17,5

--- a/balance/units/XEL0209/XEL0209_unit.bp
+++ b/balance/units/XEL0209/XEL0209_unit.bp
@@ -5,7 +5,7 @@ Merge = true,
 BlueprintId = "xel0209",
 
     Economy = {
-        BuildCostEnergy = 2100,    --75e per sec
+        BuildCostEnergy = 1400,    --75e per sec
         BuildCostMass = 280,    --10m per sec
         BuildTime = 1400,        --25s
         BuildRate = 20,            --17,5

--- a/balance/units/XEL0306/XEL0306_unit.bp
+++ b/balance/units/XEL0306/XEL0306_unit.bp
@@ -9,9 +9,9 @@ BlueprintId = "xel0306",
         MaxHealth = 1500,
     },
     Economy = {
-        BuildCostEnergy = 7875,
-        BuildCostMass = 441,
-        BuildTime = 3150,
+        BuildCostEnergy = 4400,
+        BuildCostMass = 440,
+        BuildTime = 2200,
     },
     Weapon = {
         {

--- a/balance/units/XSL0111/XSL0111_unit.bp
+++ b/balance/units/XSL0111/XSL0111_unit.bp
@@ -14,9 +14,9 @@ BlueprintId = "xsl0111",
         },
     }, 
     Economy = {
-        BuildCostEnergy = 2100,
-        BuildCostMass = 196,
-        BuildTime = 1400,
+        BuildCostEnergy = 1000,
+        BuildCostMass = 200,
+        BuildTime = 1000,
     },
     Physics = {
         MaxAcceleration = 2.4,  --from 2.7

--- a/balance/units/XSL0304/XSL0304_unit.bp
+++ b/balance/units/XSL0304/XSL0304_unit.bp
@@ -5,9 +5,9 @@ Merge = true,
 BlueprintId = "xsl0304", 
 
     Economy = {
-        BuildCostEnergy = 12000,
+        BuildCostEnergy = 8400,
         BuildCostMass = 840,
-        BuildTime = 6000,
+        BuildTime = 4200,
     },
     Weapon = {
         {

--- a/balance/units/XSL0305/XSL0305_unit.bp
+++ b/balance/units/XSL0305/XSL0305_unit.bp
@@ -164,9 +164,9 @@ UnitBlueprint {
         UniformScale = 0.08,
     },
     Economy = {
-        BuildCostEnergy = 8000,
-        BuildCostMass = 640,
-        BuildTime = 3600,
+        BuildCostEnergy = 6800,
+        BuildCostMass = 680,
+        BuildTime = 3400,
         TeleportEnergyMod = 0.15,
         TeleportMassMod = 1,
         TeleportTimeMod = 0.01,

--- a/balance/units/XSL0307/XSL0307_unit.bp
+++ b/balance/units/XSL0307/XSL0307_unit.bp
@@ -32,9 +32,9 @@ BlueprintId = "xsl0307",
         },
     },
     Economy = {
-        BuildCostEnergy = 9250,
-        BuildCostMass = 518,
-        BuildTime = 3700,
+        BuildCostEnergy = 5200,
+        BuildCostMass = 520,
+        BuildTime = 2600,
     },
     Display = {
         Abilities = {


### PR DESCRIPTION
This fix unifies factory drain values:

T2 land fac
T2 MML -10m/-50e
T2 shield/stealth gens -10m/-100e
Sparkey -10m/-50e

T3 land fac
T3 arty -20m/-200e
T3 maa -20m/-200e
Sera sniperbot -20m/-200e
Sera shield -20m/-200e
Absolver/Spearhead -20m/-200e

T3 naval fac
Strat subs -45m/-900e